### PR TITLE
Travis and badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 install:
-  - pip install ansible docker 'molecule<1.22'
+  - pip install ome-ansible-molecule-dependencies
 
 script:
   - molecule test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ OMERO Common
 ============
 
 [![Build Status](https://travis-ci.org/openmicroscopy/ansible-role-omero-common.svg)](https://travis-ci.org/openmicroscopy/ansible-role-omero-common)
-[![Ansible Role](https://img.shields.io/ansible/role/17248.svg)]()
+[![Ansible Role](https://img.shields.io/ansible/role/17248.svg)](https://galaxy.ansible.com/openmicroscopy/omero-common/)
 
 Common variables and handlers for other OMERO application Ansible roles.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 OMERO Common
 ============
 
+[![Build Status](https://travis-ci.org/openmicroscopy/ansible-role-omero-common.svg)](https://travis-ci.org/openmicroscopy/ansible-role-omero-common)
+[![Ansible Role](https://img.shields.io/ansible/role/17248.svg)]()
+
 Common variables and handlers for other OMERO application Ansible roles.
 
 


### PR DESCRIPTION
- use `ome-ansible-molecule-dependencies` as for other roles
 - add badges to the README for the CI and the deployed Galaxy role
 