### PR TITLE
Handlers pass if service not installed

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,15 +12,18 @@
   service:
     name: omero-server
     state: restarted
+  when: _omero_common_services_installed.results.0.stat.exists
 
 - name: restart omero-web
   become: yes
   service:
     name: omero-web
     state: restarted
+  when: _omero_common_services_installed.results.1.stat.exists
 
 - name: restart nginx
   become: yes
   service:
     name: nginx
     state: restarted
+  when: _omero_common_services_installed.results.2.stat.exists

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,9 +4,18 @@
     - role: ansible-role-omero-common
 
   tasks:
+
     - name: test reload systemd handler
       file:
         path: /tmp/notify-systemd-handler
         state: directory
       notify:
         - reload systemd
+
+    # Should be a noop
+    - name: test restart handler without omero-server
+      file:
+        path: /tmp/notify-omero-server-handler
+        state: directory
+      notify:
+        - restart omero-server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,3 +7,15 @@
     path: "{{ omero_common_basedir }}"
     recurse: yes
     state: directory
+
+# This lets us make handlers conditional on existence of the service
+- name: omero-common | check if services installed
+  stat:
+    path: "{{ item }}"
+  check_mode: no
+  register: _omero_common_services_installed
+  with_items:
+  # Order must match the indicies in handlers
+  - /etc/systemd/system/omero-server.service
+  - /etc/systemd/system/omero-web.service
+  - /usr/lib/systemd/system/nginx.service


### PR DESCRIPTION
If you're doing advanced configuration you may want to cater for situations where omero may or may not be installed. For example creating a custom config file `/opt/omero/server/config/xxx.omero` to configure OMERO.server before the first start-up. In this situation:
- If this is the first time the playbook is run OMERO.server is not installed, so you don't want to notify the restart handler.
- If the playbook is subsequently run and changes are made to `xxx.omero` OMERO.server will already be installed, so it should be restarted.

This PR adds a conditional so that you can notify a handler without it erroring when the service isn't installed.

Tag: maybe `0.2.0`?