### PR TITLE
Fix potential race condition when checking installation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ You should use the defaults unless you have a good reason not to.
 - `omero_common_basedir`: The parent directory for OMERO applications.
 
 
+Handlers
+--------
+
+This role includes standalone handlers which can be use to restart `omero-server` and `omero-web` without depending on the corresponding Ansible roles.
+This may be useful when modifying the configuration of OMERO after installation.
+
+If you know that the component you wish to restart is installed you can notify:
+- `restart omero-server`
+- `restart omero-web`
+- `restart nginx`
+
+If the component may or may not be installed you can notify:
+- `restart omero-server if installed`
+- `restart omero-web if installed`
+- `restart nginx if installed`
+
+Note that in the latter case the installation check is done when this role is run, not when the handlers are run, so there is a potential race condition.
+
+
 Author Information
 ------------------
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,16 +12,34 @@
   service:
     name: omero-server
     state: restarted
-  when: _omero_common_services_installed.results.0.stat.exists
 
 - name: restart omero-web
   become: yes
   service:
     name: omero-web
     state: restarted
-  when: _omero_common_services_installed.results.1.stat.exists
 
 - name: restart nginx
+  become: yes
+  service:
+    name: nginx
+    state: restarted
+
+- name: restart omero-server if installed
+  become: yes
+  service:
+    name: omero-server
+    state: restarted
+  when: _omero_common_services_installed.results.0.stat.exists
+
+- name: restart omero-web if installed
+  become: yes
+  service:
+    name: omero-web
+    state: restarted
+  when: _omero_common_services_installed.results.1.stat.exists
+
+- name: restart nginx if installed
   become: yes
   service:
     name: nginx

--- a/playbook.yml
+++ b/playbook.yml
@@ -18,4 +18,4 @@
         path: /tmp/notify-omero-server-handler
         state: directory
       notify:
-        - restart omero-server
+        - restart omero-server if installed


### PR DESCRIPTION
Follow-up to https://github.com/openmicroscopy/ansible-role-omero-common/pull/2

The installation check is done when the role is run, but the handlers may be notified and run later in a playbook. This commit forces the user to make a choice about whether to always notify the handler (this is the behaviour prior to #2), or to depend on a potentially out-of-date installation status. README updated.